### PR TITLE
Set database uri ssm

### DIFF
--- a/creeper/terraform/bkt.tf
+++ b/creeper/terraform/bkt.tf
@@ -1,0 +1,9 @@
+module "bkt" {
+  source = "./bucket"
+  name   = "creeper-bank"
+
+  tags = {
+    Name        = "Creeper"
+    Description = "Storage bank for tweets"
+  }
+}

--- a/creeper/terraform/bucket/main.tf
+++ b/creeper/terraform/bucket/main.tf
@@ -1,0 +1,24 @@
+variable "name" {
+  type = "string"
+}
+
+variable "tags" {
+  type = "map"
+}
+
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = "${var.name}"
+  acl = "private"
+
+  tags = "${var.tags}"
+}
+
+output "name" {
+  value = "${aws_s3_bucket.bucket.id}"
+}
+
+output "arn" {
+  value = "${aws_s3_bucket.bucket.arn}"
+}
+

--- a/creeper/terraform/db-remote.tf
+++ b/creeper/terraform/db-remote.tf
@@ -1,10 +1,8 @@
-data "terraform_remote_state" "config" {
-  backend = "s3"
+variable "db-uri" {
+  default = ""
+}
 
-  config {
-    bucket = "strongbank"
-    region = "us-east-1"
-    key    = "terraform/creeper-db.state"
-    region = "us-east-1"
-  }
+module "db" {
+  source = "./db"
+  db-uri = "${var.db-uri}"
 }

--- a/creeper/terraform/db/main.tf
+++ b/creeper/terraform/db/main.tf
@@ -4,7 +4,7 @@ variable "db-uri" {
 
 
 output "db-uri" {
-  value = "${var.db-uri}"
+  value = "${ local.created == 1 ? data.aws_ssm_parameter.db.value : var.db-uri }"
 }
 
 terraform {
@@ -15,21 +15,16 @@ terraform {
   }
 }
 
+data "aws_ssm_parameter" "db" {
+  name = "db-uri"
+}
 resource "aws_ssm_parameter" "db" {
+  count = "${ local.created  == 1 ? 0 : 1}"
   name  = "db-uri"
   type  = "SecureString"
   value = "${var.db-uri}"
 }
 
-
-variable shared_role_arn {
-  type = "string"
-}
-
-provider "aws" {
-  region = "us-east-1"
-
-  assume_role {
-    role_arn     = "${var.shared_role_arn}"
-  }
+locals {
+  created = "${length(data.aws_ssm_parameter.db.value) > 0}"
 }

--- a/creeper/terraform/db/main.tf
+++ b/creeper/terraform/db/main.tf
@@ -1,17 +1,9 @@
 variable "db-uri" {
-  default = ""
+  type = "string"
 }
 
-output "db-uri" {
-  value = "${aws_ssm_parameter.db.value}"
-}
-
-terraform {
-  backend "s3" {
-    bucket = "strongbank"
-    region = "us-east-1"
-    key    = "terraform/creeper-db.state"
-  }
+locals {
+  db_uri = "${coalesce(var.db-uri, data.aws_ssm_parameter.db.value)}"
 }
 
 data "aws_ssm_parameter" "db" {
@@ -21,6 +13,11 @@ data "aws_ssm_parameter" "db" {
 resource "aws_ssm_parameter" "db" {
   name  = "db-uri"
   type  = "SecureString"
-  value = "${coalesce(var.db-uri, data.aws_ssm_parameter.db.value)}"
+  value = "${local.db_uri}"
   overwrite = true
+}
+
+
+output "db-uri" {
+  value = "${local.db_uri}"
 }

--- a/creeper/terraform/db/main.tf
+++ b/creeper/terraform/db/main.tf
@@ -1,0 +1,35 @@
+variable "db-uri" {
+  default = ""
+}
+
+
+output "db-uri" {
+  value = "${var.db-uri}"
+}
+
+terraform {
+  backend "s3" {
+    bucket = "strongbank"
+    region  = "us-east-1"
+    key    = "terraform/creeper-db.state"
+  }
+}
+
+resource "aws_ssm_parameter" "db" {
+  name  = "db-uri"
+  type  = "SecureString"
+  value = "${var.db-uri}"
+}
+
+
+variable shared_role_arn {
+  type = "string"
+}
+
+provider "aws" {
+  region = "us-east-1"
+
+  assume_role {
+    role_arn     = "${var.shared_role_arn}"
+  }
+}

--- a/creeper/terraform/db/main.tf
+++ b/creeper/terraform/db/main.tf
@@ -2,15 +2,14 @@ variable "db-uri" {
   default = ""
 }
 
-
 output "db-uri" {
-  value = "${ local.created == 1 ? data.aws_ssm_parameter.db.value : var.db-uri }"
+  value = "${aws_ssm_parameter.db.value}"
 }
 
 terraform {
   backend "s3" {
     bucket = "strongbank"
-    region  = "us-east-1"
+    region = "us-east-1"
     key    = "terraform/creeper-db.state"
   }
 }
@@ -18,13 +17,10 @@ terraform {
 data "aws_ssm_parameter" "db" {
   name = "db-uri"
 }
+
 resource "aws_ssm_parameter" "db" {
-  count = "${ local.created  == 1 ? 0 : 1}"
   name  = "db-uri"
   type  = "SecureString"
-  value = "${var.db-uri}"
-}
-
-locals {
-  created = "${length(data.aws_ssm_parameter.db.value) > 0}"
+  value = "${coalesce(var.db-uri, data.aws_ssm_parameter.db.value)}"
+  overwrite = true
 }

--- a/creeper/terraform/main.tf
+++ b/creeper/terraform/main.tf
@@ -15,7 +15,7 @@ resource "aws_lambda_function" "creeper-function" {
 
   environment {
     variables = {
-      DB_URI = "${data.terraform_remote_state.config.db-uri}"
+      DB_URI = "${module.db.db-uri}"
     }
   }
 }

--- a/creeper/terraform/main.tf
+++ b/creeper/terraform/main.tf
@@ -1,8 +1,8 @@
 data "archive_file" "creeper-zip" {
-  type        = "zip"
+  type                    = "zip"
   source_content          = "# nothing to do"
   source_content_filename = "creeper.Main::fetchTweets"
-  output_path = "${path.module}/creeper.zip"
+  output_path             = "${path.module}/creeper.zip"
 }
 
 resource "aws_lambda_function" "creeper-function" {
@@ -16,6 +16,7 @@ resource "aws_lambda_function" "creeper-function" {
   environment {
     variables = {
       DB_URI = "${module.db.db-uri}"
+      BUCKET = "${module.bkt.name}"
     }
   }
 }

--- a/creeper/terraform/provider.tf
+++ b/creeper/terraform/provider.tf
@@ -3,9 +3,14 @@ variable shared_role_arn {
 }
 
 provider "aws" {
-  region = "us-east-1"
+  region  = "us-east-1"
+  version = "~> 1.35"
 
   assume_role {
-    role_arn     = "${var.shared_role_arn}"
+    role_arn = "${var.shared_role_arn}"
   }
+}
+
+provider "archive" {
+  version = "~> 1.1"
 }


### PR DESCRIPTION
This simplifies the creation of the `db-uri parameter in AWS SSM
by separating it to a separate terraform configuration module.

The SSM parameter value for `db-uri` is created or overwritten on condition 
that `db-uri` is set when terraform is run.