### PR TITLE
[#3] Build Twitter search query string

### DIFF
--- a/creeper/src/main/scala/creeper/TwitterSearch.scala
+++ b/creeper/src/main/scala/creeper/TwitterSearch.scala
@@ -1,0 +1,29 @@
+package creeper
+
+import java.net.URLEncoder
+
+object TwitterSearch {
+  def queryAtCharLimits(parties: List[Party]): List[String] = {
+    val search = parties.flatMap(
+      p => List(
+        s""""${p.name.trim.toLowerCase}"""", p.aliases.fold ("")(_ ++ _)
+      )
+    )
+    val nonEmptySearch = search
+        .filter(s => s != "")
+
+    var queries = List[String]()
+    val sb = new StringBuilder
+    val op = "%20OR%20"
+    for (s <- nonEmptySearch) {
+      sb ++= URLEncoder.encode(s, "UTF-8")
+      sb ++= op
+      if(sb.lengthCompare(490) > 0) {
+          queries :+= sb.stripSuffix(op).mkString
+          sb.clear()
+      }
+    }
+    queries :+= sb.stripSuffix(op).mkString
+    return queries
+  }
+}

--- a/creeper/src/test/scala/TwitterSearchSpec.scala
+++ b/creeper/src/test/scala/TwitterSearchSpec.scala
@@ -1,0 +1,40 @@
+import org.scalatest._
+
+import creeper.{TwitterSearch, Party}
+
+
+class TwitterSearchSpec extends FunSuite with DiagrammedAssertions {
+  test("TwitterSearch can make query at char limits") {
+    val parties = List[Party](
+      Party("3 Legs", "3LEGS", List[String]()),
+      Party("4 Legs", "4LEGS", List[String]())
+    )
+
+    assert(
+      TwitterSearch
+        .queryAtCharLimits(parties)
+        .exists(_ == "%223+legs%22%20OR%20%224+legs%22")
+    )
+  }
+
+  test("TwitterSearch can make queries when above char limits") {
+    val parties = List[Party](
+      Party("3 Legs", "3LEGS", List[String](
+        "If the Easter Bunny and the Tooth Fairy had babies would they take your teeth and leave chocolate for you?",
+        "I love eating toasted cheese and tuna sandwiches.",
+        "Last Friday in three week’s time I saw a spotted striped blue worm shake hands with a legless lizard.",
+        "She folded her handkerchief neatly.",
+        "Sixty-Four comes asking for bread.",
+        "Sometimes it is better to just walk away from things and go back to them later when you’re in a better frame of mind.",
+        "The memory we used to share is no longer coherent."
+      )),
+      Party("4 Legs", "4LEGS", List[String]())
+    )
+    assert(
+      TwitterSearch
+        .queryAtCharLimits(parties)
+        .length == 2
+    )
+  }
+
+}


### PR DESCRIPTION
The Twitter search API exposes a constraint on the number of characters
that can be passed for the "q" query parameter to be 500 characters.

It is intended to separate the query along this line into batches and
carry out the search.